### PR TITLE
faat inline 클래스를 통한 사용자 아이디 검증 로직 구현 및 테스트 코드 작성

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,8 @@ dependencies {
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
+	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+
 	// Mysql 의존성
 	implementation("mysql:mysql-connector-java:8.0.33")
 	implementation("mysql:mysql-connector-java")

--- a/src/main/kotlin/com/example/kotlinPro/KotlinProApplication.kt
+++ b/src/main/kotlin/com/example/kotlinPro/KotlinProApplication.kt
@@ -3,6 +3,7 @@ package com.example.kotlinPro
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import java.time.LocalDate
 import kotlin.math.roundToInt
 
 @EnableJpaAuditing
@@ -12,3 +13,4 @@ class KotlinProApplication
 fun main(args: Array<String>) {
 	runApplication<KotlinProApplication>(*args)
 }
+

--- a/src/main/kotlin/com/example/kotlinPro/member/MemberController.kt
+++ b/src/main/kotlin/com/example/kotlinPro/member/MemberController.kt
@@ -1,8 +1,5 @@
 package com.example.kotlinPro.member
 
-import com.example.kotlinPro.jwt.JwtUtil
-import com.example.kotlinPro.tripException.ErrorCode
-import com.example.kotlinPro.tripException.TripException
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpStatus
@@ -24,6 +21,12 @@ private val log = KotlinLogging.logger {}
 class MemberController(
     private val memberService: MemberService,
 ) {
+
+    // 사용자 아이디 검증 로직 테스트
+    @PostMapping("/check/username")
+    fun checkUsername(@RequestBody request: CheckInfoUsername) {
+        println("유효한 아이디: ${request.username}")
+    }
 
     // 사용자 등록 ( 회원가입 )
     @PostMapping("/register", consumes = ["multipart/form-data"])
@@ -82,3 +85,5 @@ class MemberController(
         return memberService.getProfileImage(username)
     }
 }
+
+data class CheckInfoUsername(val username: CheckUsername)

--- a/src/main/kotlin/com/example/kotlinPro/member/MemberRepository.kt
+++ b/src/main/kotlin/com/example/kotlinPro/member/MemberRepository.kt
@@ -1,6 +1,7 @@
 package com.example.kotlinPro.member
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
 
 interface MemberRepository: JpaRepository<Member, Long> {
 

--- a/src/main/kotlin/com/example/kotlinPro/member/MemberResDto.kt
+++ b/src/main/kotlin/com/example/kotlinPro/member/MemberResDto.kt
@@ -20,4 +20,3 @@ data class MemberResDto (
     val followings: List<String>? = null,
     val messageList: List<MessageResDto>? = null
 )
-{}

--- a/src/test/kotlin/com/example/kotlinPro/MemberInfo.kt
+++ b/src/test/kotlin/com/example/kotlinPro/MemberInfo.kt
@@ -1,0 +1,13 @@
+package com.example.kotlinPro
+
+data class MemberInfo (
+    val name: String,
+    val age: Int,
+
+) {
+
+    init {
+        require(age >= 10)
+        require(name.length in 1..6)
+    }
+}

--- a/src/test/kotlin/com/example/kotlinPro/ValidUsernameTest.kt
+++ b/src/test/kotlin/com/example/kotlinPro/ValidUsernameTest.kt
@@ -1,0 +1,53 @@
+package com.example.kotlinPro
+
+import com.example.kotlinPro.member.CheckUsername
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import kotlin.test.Test
+
+class ValidUsernameTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = ["A1@abc", "T9%Test", "Z1^xyz", "@A1B2C"])
+    fun `유효한 사용자명은 정상 생성`(input: String) {
+        val result = CheckUsername(input)
+        println("성공: $result")
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = [
+        "A1abc",       // 특수문자 없음
+        "a1@abc",      // 대문자 없음
+        "ABC@def",     // 숫자 없음
+        "A1\$abc",     // 허용되지 않은 특수문자
+        "A1@ bc",      // 공백 포함
+        "A1@-bc",      // 하이픈 포함
+        "abc"          // 전부 없음
+    ])
+    fun `유효하지 않은 사용자명은 예외가 발생`(input: String) {
+        assertThrows<IllegalArgumentException> {
+            CheckUsername(input)
+        }
+    }
+
+    @Test
+    fun `이름 길이 초과 시 예외 발생`() {
+        val name = "ABCDEFG" // 7자
+        assertThrows<IllegalArgumentException> {
+            successMemberInfo.copy(name = name)
+        }
+    }
+
+    @Test
+    fun `10세 미만은 예외 발생`() {
+        assertThrows<IllegalArgumentException> {
+            MemberInfo(name = "lee", age = 9)
+        }
+    }
+
+    private val successMemberInfo = MemberInfo(
+        name = "park",
+        age = 26,
+    )
+}


### PR DESCRIPTION
inline 클래스를 통해 사용자 id 검증 로직을 구현하고, 이에 대한 테스트 코드 작성
테스트 코드 작성 시 data class의 copy() 함수로 테스트 코드의 가독성 및 간편화